### PR TITLE
Allows construction of windoors by an RCD and nerfs virus healing a lot

### DIFF
--- a/code/datums/diseases/advance/symptoms/damage_converter.dm
+++ b/code/datums/diseases/advance/symptoms/damage_converter.dm
@@ -36,7 +36,7 @@ Bonus
 /datum/symptom/damage_converter/proc/Convert(mob/living/M)
 
 	var/get_damage = 1.5
-
+/*
 	if(istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
 
@@ -47,13 +47,12 @@ Bonus
 
 		for(var/obj/item/organ/limb/L in parts)
 			L.heal_damage(get_damage, get_damage, 0)
-
+*/
+	if(M.getFireLoss() > 0 || M.getBruteLoss() > 0)
+		M.adjustFireLoss(-get_damage)
+		M.adjustBruteLoss(-get_damage)
 	else
-		if(M.getFireLoss() > 0 || M.getBruteLoss() > 0)
-			M.adjustFireLoss(-get_damage)
-			M.adjustBruteLoss(-get_damage)
-		else
-			return
+		return
 
 	M.adjustToxLoss(get_damage)
 	return 1


### PR DESCRIPTION
Turns out virus healing is extremely broke if someone/something damages multiple limbs at once

Windoors are basically like glass airlocks but now windows, you can use this as a way to safety transfer items on a table without fear of getting shot (2 windoors on a table) and cost as much as a airlock to make as well as the same amount of time. 